### PR TITLE
Work well with older `lock_api` versions

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -181,7 +181,7 @@ struct Shard<K, V> {
 }
 
 impl<K, V> Shard<K, V> {
-    const fn new() -> Self {
+    fn new() -> Self {
         Self {
             map: RwLock::new(HashMap::new()),
             waiters: Mutex::new(HashMap::new()),


### PR DESCRIPTION
The crate `lock_api` is a transitive dependency, pulled in trough the use of `parking_lot`. `parking_lot` depends on `lock_api` version `^0.4.6`, but only since `lock_api` 0.4.7 the `RwLock::new()` method is available on rust stable, coinciding with the release of rust [1.61][const_fn_trait_bound].

A problem occurs if you try to use `once_map` with non-up-to-date dependencies, e.g. by running

```sh
RUSTC_BOOTSTRAP=1 cargo generate-lockfile -Zminimal-versions
```

~~This PR replaces the use of `RwLock::new()` with `RwLock::const_new()`, which was already available in `lock_api` 0.4.6.~~

This PR makes `Shard::new()` non-`const`, so it works with older `lock_api` versions, too.

[const_fn_trait_bound]: <https://caniuse.rs/features/const_fn_trait_bound>